### PR TITLE
fix(tui): resolve iTerm2 scrollback buffer pollution in store and vie…

### DIFF
--- a/python/src/tui/text_utils.py
+++ b/python/src/tui/text_utils.py
@@ -1,5 +1,7 @@
 """Text utility functions for TUI components."""
 
+import os
+import sys
 from typing import List, Iterable
 from wcwidth import wcswidth
 
@@ -115,3 +117,15 @@ def truncate_with_ellipsis(text: str, width: int, ellipsis: str = "...") -> str:
         acc += w
         out_chars.append(ch)
     return "".join(out_chars) + ellipsis
+
+
+def is_iterm2() -> bool:
+    """Check if running in iTerm2."""
+    return os.environ.get('TERM_PROGRAM') == 'iTerm.app'
+
+
+def clear_iterm2_scrollback() -> None:
+    """Clear iTerm2 scrollback buffer."""
+    if is_iterm2():
+        sys.stdout.write('\033[2J\033[H\033[3J')
+        sys.stdout.flush()

--- a/python/src/tui/view_app.py
+++ b/python/src/tui/view_app.py
@@ -108,6 +108,10 @@ class TigsViewApp:
             
             # Check minimum size
             if width < self.MIN_WIDTH or height < self.MIN_HEIGHT:
+                # iTerm2 scrollback fix for small window message
+                if os.environ.get('TERM_PROGRAM') == 'iTerm.app':
+                    sys.stdout.write('\033[2J\033[H\033[3J')
+                    sys.stdout.flush()
                 stdscr.clear()
                 msg = f"Terminal too small: {width}x{height} (min: {self.MIN_WIDTH}x{self.MIN_HEIGHT})"
                 try:
@@ -120,7 +124,16 @@ class TigsViewApp:
                     self.running = False
                 continue
             
-            # Clear screen
+            # iTerm2 scrollback fix
+            import sys
+            import os
+
+            # Clear screen with iTerm2 scrollback fix
+            if os.environ.get('TERM_PROGRAM') == 'iTerm.app':
+                # Clear screen + scrollback for iTerm2
+                sys.stdout.write('\033[2J\033[H\033[3J')  # The key: \033[3J clears scrollback!
+                sys.stdout.flush()
+
             stdscr.clear()
             
             # Calculate column widths using layout manager for consistency with store

--- a/python/src/tui/view_app.py
+++ b/python/src/tui/view_app.py
@@ -10,6 +10,7 @@ from .commit_details_view import CommitDetailsView
 from .chat_view import ChatView
 from .layout_manager import LayoutManager
 from .pane_renderer import PaneRenderer
+from .text_utils import clear_iterm2_scrollback
 
 
 class TigsViewApp:
@@ -108,10 +109,8 @@ class TigsViewApp:
             
             # Check minimum size
             if width < self.MIN_WIDTH or height < self.MIN_HEIGHT:
-                # iTerm2 scrollback fix for small window message
-                if os.environ.get('TERM_PROGRAM') == 'iTerm.app':
-                    sys.stdout.write('\033[2J\033[H\033[3J')
-                    sys.stdout.flush()
+                # Clear iTerm2 scrollback buffer + standard curses clear
+                clear_iterm2_scrollback()
                 stdscr.clear()
                 msg = f"Terminal too small: {width}x{height} (min: {self.MIN_WIDTH}x{self.MIN_HEIGHT})"
                 try:
@@ -124,16 +123,8 @@ class TigsViewApp:
                     self.running = False
                 continue
             
-            # iTerm2 scrollback fix
-            import sys
-            import os
-
-            # Clear screen with iTerm2 scrollback fix
-            if os.environ.get('TERM_PROGRAM') == 'iTerm.app':
-                # Clear screen + scrollback for iTerm2
-                sys.stdout.write('\033[2J\033[H\033[3J')  # The key: \033[3J clears scrollback!
-                sys.stdout.flush()
-
+            # Clear iTerm2 scrollback buffer + standard curses clear
+            clear_iterm2_scrollback()
             stdscr.clear()
             
             # Calculate column widths using layout manager for consistency with store


### PR DESCRIPTION
Summary

  - Fix duplicate window stacking issue in iTerm2 when using Tab/Space keys in tigs store and tigs view commands
  - Extract iTerm2 utility functions to shared module for better code organization
  - Simplify TUI application initialization by removing redundant alternate screen buffer management

  Problem

  When using tigs store or tigs view in iTerm2, pressing Tab or Space keys would create duplicate 3-panel windows that accumulate in the terminal scrollback buffer. This issue was specific to iTerm2 and
  didn't occur in native Terminal.app.

  Solution

  - Added \033[2J\033[H\033[3J escape sequence to clear iTerm2 scrollback buffer on each screen refresh
  - Created shared utility functions is_iterm2() and clear_iterm2_scrollback() in text_utils.py
  - Removed duplicate iTerm2 detection code from both TUI applications
  - Simplified store_app.py by removing unnecessary alternate screen buffer management

  Test plan

  - Test tigs store in iTerm2 - no duplicate windows when pressing Tab/Space
  - Test tigs view in iTerm2 - no duplicate windows when pressing Tab/Space
  - Test both commands in native Terminal.app - continues to work normally
  - Verify code refactoring maintains all existing functionality

  🤖 Generated with https://claude.ai/code