### PR TITLE
fix(tui): add Space key instruction to status bar (#48)

### DIFF
--- a/python/src/tui/store_app.py
+++ b/python/src/tui/store_app.py
@@ -248,9 +248,9 @@ class TigsStoreApp:
                 status_text = self.status_message
             else:
                 self.status_message = ""  # Clear old message
-                status_text = "Tab: switch | Enter: store | q: quit"
+                status_text = "Tab: switch | Space: select | Enter: store | q: quit"
         else:
-            status_text = "Tab: switch | Enter: store | q: quit"
+            status_text = "Tab: switch | Space: select | Enter: store | q: quit"
         
         # Add size warning if getting close to minimum
         height = stdscr.getmaxyx()[0]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -686,7 +686,7 @@ wheels = [
 
 [[package]]
 name = "tigs"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Adds "Space: select" instruction to the status bar in `tigs store`
- Makes the existing selection functionality discoverable to users

## Test plan
- [x] Ran test suite - three legacy failures
- [x] The status bar now shows: "Tab: switch | Space: select | Enter: store | q: quit"

Fixes #48

🤖 Generated with [Claude Code](https://claude.ai/code)