### PR TITLE
feat(tui): add status footer to commits, messages and logs views

### DIFF
--- a/python/src/tui/store_app.py
+++ b/python/src/tui/store_app.py
@@ -199,7 +199,7 @@ class TigsStoreApp:
             
             # Get log display lines and draw logs pane only if wide enough
             if log_pane_width >= 2:
-                log_lines = self.log_view.get_display_lines(pane_height)
+                log_lines = self.log_view.get_display_lines(pane_height, log_pane_width, self._colors_enabled)
                 PaneRenderer.draw_pane(stdscr, 0, commit_width + message_width, pane_height, log_pane_width,
                                       "Logs", self.focused_pane == 2,
                                       log_lines, self._colors_enabled)

--- a/python/tests/test_commits_status_footer.py
+++ b/python/tests/test_commits_status_footer.py
@@ -1,0 +1,198 @@
+"""Tests for status footer in commits view."""
+
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime
+
+from src.tui.commits_view import CommitView
+from src.tui.color_constants import COLOR_METADATA, COLOR_DEFAULT
+
+
+class TestCommitsStatusFooter:
+    """Test status footer functionality in commits view."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_store = Mock()
+        self.mock_store.repo_path = '/test/repo'
+        self.mock_store.list_chats.return_value = []
+
+        # Patch the load_commits to avoid subprocess calls
+        with patch.object(CommitView, 'load_commits'):
+            self.view = CommitView(self.mock_store)
+
+        # Sample commits
+        self.view.commits = [
+            {
+                'sha': f'{i:06x}',
+                'full_sha': f'{i:040x}',
+                'author': f'Author{i}',
+                'time': datetime(2025, 9, 10, 12 - i, 0),  # Vary hours instead of days
+                'subject': f'Commit {i}',
+                'has_note': False
+            }
+            for i in range(1, 11)  # 10 commits
+        ]
+        self.view.items = self.view.commits
+        self.view.cursor_idx = 0
+
+    def test_status_footer_appears_with_commits(self):
+        """Test that status footer appears when commits are present."""
+        lines = self.view.get_display_lines(height=20, width=80, colors_enabled=False)
+
+        # Look for status footer
+        footer_found = False
+        for line in lines[-5:]:  # Check last few lines
+            if "(" in line and "/" in line and ")" in line:
+                footer_found = True
+                # Should show (1/10) for first position
+                assert "(1/10)" in line, f"Expected (1/10) in footer, got: {line}"
+                break
+
+        assert footer_found, "Status footer not found in display lines"
+
+    def test_status_footer_updates_with_cursor(self):
+        """Test that status footer updates when cursor moves."""
+        # Initial position
+        lines = self.view.get_display_lines(height=20, width=80, colors_enabled=False)
+        initial_footer = None
+        for line in lines[-5:]:
+            if "(" in line and "/" in line and ")" in line:
+                initial_footer = line.strip()
+                break
+        assert "(1/10)" in initial_footer
+
+        # Move cursor to position 4 (0-indexed, so shows as 5)
+        self.view.cursor_idx = 4
+        lines = self.view.get_display_lines(height=20, width=80, colors_enabled=False)
+        updated_footer = None
+        for line in lines[-5:]:
+            if "(" in line and "/" in line and ")" in line:
+                updated_footer = line.strip()
+                break
+        assert "(5/10)" in updated_footer, f"Expected (5/10), got: {updated_footer}"
+
+        # Move to last position
+        self.view.cursor_idx = 9
+        lines = self.view.get_display_lines(height=20, width=80, colors_enabled=False)
+        final_footer = None
+        for line in lines[-5:]:
+            if "(" in line and "/" in line and ")" in line:
+                final_footer = line.strip()
+                break
+        assert "(10/10)" in final_footer, f"Expected (10/10), got: {final_footer}"
+
+    def test_status_footer_no_commits(self):
+        """Test that no footer appears when there are no commits."""
+        self.view.commits = []
+        self.view.items = []
+
+        lines = self.view.get_display_lines(height=20, width=80, colors_enabled=False)
+
+        # Should not have status footer
+        footer_found = False
+        for line in lines:
+            if "(" in line and "/" in line and ")" in line and any(c.isdigit() for c in line):
+                footer_found = True
+                break
+
+        assert not footer_found, "Should not show status footer when no commits"
+        # Should show "No commits" message instead
+        assert any("No commits" in line for line in lines), "Should show 'No commits' message"
+
+    def test_status_footer_colored(self):
+        """Test that status footer uses metadata color when colors enabled."""
+        lines = self.view.get_display_lines(height=20, width=80, colors_enabled=True)
+
+        # Look for colored footer
+        footer_found = False
+        for line in lines[-5:]:
+            if isinstance(line, list):  # Colored lines are lists of tuples
+                text = "".join(t for t, _ in line)
+                if "(" in text and "/" in text and ")" in text:
+                    footer_found = True
+                    # Check color of footer
+                    for part_text, part_color in line:
+                        if "(" in part_text:  # Found the footer part
+                            assert part_color == COLOR_METADATA, f"Footer should use COLOR_METADATA, got {part_color}"
+                    break
+
+        assert footer_found, "Colored status footer not found"
+
+    def test_status_footer_right_aligned(self):
+        """Test that status footer is right-aligned."""
+        width = 60
+        lines = self.view.get_display_lines(height=20, width=width, colors_enabled=False)
+
+        # Find footer
+        footer_line = None
+        for line in lines[-5:]:
+            if "(" in line and "/" in line and ")" in line:
+                footer_line = line
+                break
+
+        assert footer_line is not None, "Footer not found"
+
+        # Footer should be right-aligned (end with the status text)
+        assert footer_line.rstrip().endswith(")"), "Footer should be right-aligned"
+        assert "(1/10)" in footer_line
+
+        # Check that it's padded with spaces on the left
+        assert footer_line.startswith(" "), "Footer should have left padding for right alignment"
+
+    def test_status_footer_with_single_commit(self):
+        """Test status footer with single commit."""
+        self.view.commits = [{
+            'sha': 'abc123',
+            'full_sha': 'abc123' * 6,
+            'author': 'Solo',
+            'time': datetime(2025, 9, 10, 12, 0),
+            'subject': 'Single commit',
+            'has_note': False
+        }]
+        self.view.items = self.view.commits
+        self.view.cursor_idx = 0
+
+        lines = self.view.get_display_lines(height=20, width=80, colors_enabled=False)
+
+        footer_found = False
+        for line in lines[-5:]:
+            if "(" in line and "/" in line and ")" in line:
+                footer_found = True
+                assert "(1/1)" in line, f"Expected (1/1) for single commit, got: {line}"
+                break
+
+        assert footer_found, "Footer should appear even with single commit"
+
+    def test_status_footer_in_read_only_mode(self):
+        """Test that status footer appears in read-only mode."""
+        # Create view in read-only mode
+        with patch.object(CommitView, 'load_commits'):
+            read_only_view = CommitView(self.mock_store, read_only=True)
+
+        read_only_view.commits = self.view.commits[:5]  # 5 commits
+        read_only_view.items = read_only_view.commits
+        read_only_view.cursor_idx = 2
+
+        lines = read_only_view.get_display_lines(height=20, width=80, colors_enabled=False)
+
+        footer_found = False
+        for line in lines[-5:]:
+            if "(" in line and "/" in line and ")" in line:
+                footer_found = True
+                assert "(3/5)" in line, f"Expected (3/5) in read-only mode, got: {line}"
+                break
+
+        assert footer_found, "Status footer should appear in read-only mode"
+
+    def test_status_footer_respects_height_limit(self):
+        """Test that footer doesn't exceed available height."""
+        # Very limited height
+        lines = self.view.get_display_lines(height=5, width=80, colors_enabled=False)
+
+        # Should not exceed height limit (height includes borders, so content is height-2)
+        assert len(lines) <= 5, f"Lines should fit within height limit, got {len(lines)} lines"
+
+        # Footer might not appear if no room, or might appear if there's space
+        footer_found = any("(" in line and "/" in line and ")" in line for line in lines)
+        # Either case is acceptable - footer is optional if no space

--- a/python/tests/test_commits_view_colors.py
+++ b/python/tests/test_commits_view_colors.py
@@ -115,20 +115,23 @@ class TestCommitsViewColors:
         """Test that wrapped commit lines maintain consistent colors."""
         # Use narrow width to force wrapping
         lines = self.view.get_display_lines(height=20, width=40, colors_enabled=True)
-        
+
         # Find wrapped lines (indented continuation lines)
         wrapped_found = False
         for i, line in enumerate(lines):
             if isinstance(line, list):
                 text_parts = "".join(t for t, _ in line)
-                # Wrapped lines typically start with spaces
+                # Skip the status footer (it contains parentheses with numbers)
+                if "(" in text_parts and "/" in text_parts and ")" in text_parts:
+                    continue
+                # Wrapped lines typically start with spaces (4 spaces for continuation)
                 if text_parts.startswith("    "):
                     wrapped_found = True
                     # Check that wrapped content has consistent color
                     for text, color in line:
                         if text.strip():  # Non-whitespace content
                             assert color == COLOR_DEFAULT, f"Wrapped content should be default: {text}"
-        
+
         assert wrapped_found, "No wrapped lines found with narrow width"
     
     def test_long_author_name_coloring(self):

--- a/python/tests/test_logs_status_footer.py
+++ b/python/tests/test_logs_status_footer.py
@@ -1,0 +1,231 @@
+"""Tests for status footer in logs view."""
+
+import pytest
+from unittest.mock import Mock
+from datetime import datetime, timedelta
+
+from src.tui.logs_view import LogsView
+from src.tui.color_constants import COLOR_METADATA
+
+
+class TestLogsStatusFooter:
+    """Test status footer functionality in logs view."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_parser = Mock()
+        self.view = LogsView(self.mock_parser)
+
+        # Create sample logs with metadata
+        base_time = datetime.now()
+        self.view.logs = [
+            ('log_001', {'modified': (base_time - timedelta(hours=0)).isoformat()}),
+            ('log_002', {'modified': (base_time - timedelta(hours=1)).isoformat()}),
+            ('log_003', {'modified': (base_time - timedelta(hours=2)).isoformat()}),
+            ('log_004', {'modified': (base_time - timedelta(hours=3)).isoformat()}),
+            ('log_005', {'modified': (base_time - timedelta(hours=4)).isoformat()}),
+        ]
+        self.view.selected_log_idx = 0
+        self.view.log_scroll_offset = 0
+
+    def test_status_footer_appears_with_logs(self):
+        """Test that status footer appears when logs are present."""
+        lines = self.view.get_display_lines(height=20)
+
+        # Look for status footer
+        footer_found = False
+        for line in lines[-3:]:  # Check last few lines
+            if "(" in line and "/" in line and ")" in line:
+                footer_found = True
+                # Should show (1/5) for first position
+                assert "(1/5)" in line, f"Expected (1/5) in footer, got: {line}"
+                break
+
+        assert footer_found, "Status footer not found in display lines"
+
+    def test_status_footer_updates_with_selection(self):
+        """Test that status footer updates when selection changes."""
+        # Initial position
+        lines = self.view.get_display_lines(height=20)
+        initial_footer = None
+        for line in lines[-3:]:
+            if "(" in line and "/" in line and ")" in line:
+                initial_footer = line.strip()
+                break
+        assert "(1/5)" in initial_footer
+
+        # Move selection to position 2
+        self.view.selected_log_idx = 2
+        lines = self.view.get_display_lines(height=20)
+        updated_footer = None
+        for line in lines[-3:]:
+            if "(" in line and "/" in line and ")" in line:
+                updated_footer = line.strip()
+                break
+        assert "(3/5)" in updated_footer, f"Expected (3/5), got: {updated_footer}"
+
+        # Move to last position
+        self.view.selected_log_idx = 4
+        lines = self.view.get_display_lines(height=20)
+        final_footer = None
+        for line in lines[-3:]:
+            if "(" in line and "/" in line and ")" in line:
+                final_footer = line.strip()
+                break
+        assert "(5/5)" in final_footer, f"Expected (5/5), got: {final_footer}"
+
+    def test_status_footer_no_logs(self):
+        """Test that no footer appears when there are no logs."""
+        self.view.logs = []
+
+        lines = self.view.get_display_lines(height=20)
+
+        # Should not have status footer
+        footer_found = False
+        for line in lines:
+            if "(" in line and "/" in line and ")" in line:
+                if any(c.isdigit() for c in line):
+                    footer_found = True
+                    break
+
+        assert not footer_found, "Should not show status footer when no logs"
+        # Should show "No logs found" message instead
+        assert any("No logs found" in line for line in lines), "Should show 'No logs found' message"
+
+    def test_status_footer_right_aligned(self):
+        """Test that status footer is right-aligned."""
+        lines = self.view.get_display_lines(height=20)
+
+        # Find footer
+        footer_line = None
+        for line in lines[-3:]:
+            if "(" in line and "/" in line and ")" in line:
+                footer_line = line
+                break
+
+        assert footer_line is not None, "Footer not found"
+
+        # Footer should be right-aligned (logs pane is narrow)
+        assert footer_line.rstrip().endswith(")"), "Footer should be right-aligned"
+        assert "(1/5)" in footer_line
+
+        # Check that it's padded with spaces on the left
+        assert footer_line.startswith(" "), "Footer should have left padding for right alignment"
+
+    def test_status_footer_with_single_log(self):
+        """Test status footer with single log."""
+        self.view.logs = [('single_log', {'modified': datetime.now().isoformat()})]
+        self.view.selected_log_idx = 0
+
+        lines = self.view.get_display_lines(height=20)
+
+        footer_found = False
+        for line in lines[-3:]:
+            if "(" in line and "/" in line and ")" in line:
+                footer_found = True
+                assert "(1/1)" in line, f"Expected (1/1) for single log, got: {line}"
+                break
+
+        assert footer_found, "Footer should appear even with single log"
+
+    def test_status_footer_respects_height_limit(self):
+        """Test that footer fits within available height."""
+        # Very limited height
+        lines = self.view.get_display_lines(height=8)
+
+        # Should not exceed height limit minus borders
+        assert len(lines) <= 6, f"Lines should fit within height limit, got {len(lines)} lines"
+
+        # Footer should still appear if there's room
+        footer_found = any(
+            "(" in line and "/" in line and ")" in line
+            for line in lines
+        )
+        # With height 8, we have 6 lines available (8-2 borders), so footer should appear
+        assert footer_found, "Footer should appear when there's room"
+
+    def test_status_footer_with_scrolling(self):
+        """Test that footer shows correct position during scrolling."""
+        # Create many logs to enable scrolling
+        base_time = datetime.now()
+        self.view.logs = [
+            (f'log_{i:03d}', {'modified': (base_time - timedelta(hours=i)).isoformat()})
+            for i in range(20)
+        ]
+        self.view.selected_log_idx = 10
+        self.view.log_scroll_offset = 5
+
+        lines = self.view.get_display_lines(height=10)
+
+        # Footer should show current selection, not scroll offset
+        footer_found = False
+        for line in lines[-3:]:
+            if "(" in line and "/" in line and ")" in line:
+                footer_found = True
+                assert "(11/20)" in line, f"Expected (11/20) for position 10, got: {line}"
+                break
+
+        assert footer_found, "Footer should show during scrolling"
+
+    def test_status_footer_truncation_narrow_width(self):
+        """Test that footer is truncated when too wide for pane."""
+        # Create many logs to get double-digit numbers
+        base_time = datetime.now()
+        self.view.logs = [
+            (f'log_{i:03d}', {'modified': (base_time - timedelta(hours=i)).isoformat()})
+            for i in range(100)
+        ]
+        self.view.selected_log_idx = 99
+
+        # Test with very narrow width (e.g., 10 total, 6 usable after borders and padding)
+        lines = self.view.get_display_lines(height=20, width=10)
+
+        # Find the footer
+        footer_line = lines[-1] if lines else ""
+
+        # With width 10, we have 6 chars after borders and padding (10 - 4)
+        # "(100/100)" is 10 chars, so it should be truncated to "(100/1"
+        assert len(footer_line) <= 6, f"Footer should be truncated to fit width, got: '{footer_line}' with length {len(footer_line)}"
+
+        # The footer should be truncated
+        assert "(100/1" in footer_line or len(footer_line) == 6, f"Footer should be truncated, got: '{footer_line}'"
+
+    def test_status_footer_different_widths(self):
+        """Test footer behavior with different pane widths."""
+        # Test with standard logs pane width (17)
+        lines = self.view.get_display_lines(height=20, width=17)
+        footer = lines[-1] if lines else ""
+        assert "(1/5)" in footer, f"Footer should show correctly at standard width, got: '{footer}'"
+
+        # Test with narrower width (12)
+        lines = self.view.get_display_lines(height=20, width=12)
+        footer = lines[-1] if lines else ""
+        # Width 12 - 4 (borders+padding) = 8 usable, "(1/5)" is 5 chars, should fit with padding
+        assert "(1/5)" in footer, f"Footer should show at width 12, got: '{footer}'"
+        assert len(footer) <= 8, f"Footer should not exceed usable width"
+
+        # Test with very narrow width (9)
+        lines = self.view.get_display_lines(height=20, width=9)
+        footer = lines[-1] if lines else ""
+        # Width 9 - 4 = 5 usable, "(1/5)" is 5 chars, should just fit
+        assert len(footer) <= 5, f"Footer should fit within 5 chars, got: '{footer}' with length {len(footer)}"
+        assert "(1/5)" in footer or footer == "(1/5", f"Footer should show or be truncated, got: '{footer}'"
+
+    def test_status_footer_colored(self):
+        """Test that status footer uses metadata color when colors enabled."""
+        lines = self.view.get_display_lines(height=20, width=17, colors_enabled=True)
+
+        # Look for colored footer
+        footer_found = False
+        for line in lines[-3:]:
+            if isinstance(line, list):  # Colored lines are lists of tuples
+                text = "".join(t for t, _ in line)
+                if "(" in text and "/" in text and ")" in text:
+                    footer_found = True
+                    # Check color of footer
+                    for part_text, part_color in line:
+                        if "(" in part_text:  # Found the footer part
+                            assert part_color == COLOR_METADATA, f"Footer should use COLOR_METADATA, got {part_color}"
+                    break
+
+        assert footer_found, "Colored status footer not found"

--- a/python/tests/test_messages_status_footer.py
+++ b/python/tests/test_messages_status_footer.py
@@ -1,0 +1,169 @@
+"""Tests for status footer in messages view."""
+
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime
+
+from src.tui.messages_view import MessageView
+from src.tui.color_constants import COLOR_METADATA, COLOR_DEFAULT
+
+
+class TestMessagesStatusFooter:
+    """Test status footer functionality in messages view."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_parser = Mock()
+        self.view = MessageView(self.mock_parser)
+
+        # Create sample messages
+        self.view.messages = [
+            ('user', 'Hello, how are you?', datetime(2025, 9, 10, 10, 0)),
+            ('assistant', 'I am doing well, thank you!', datetime(2025, 9, 10, 10, 1)),
+            ('user', 'Can you help me with Python?', datetime(2025, 9, 10, 10, 2)),
+            ('assistant', 'Of course! I would be happy to help.', datetime(2025, 9, 10, 10, 3)),
+            ('user', 'Great, thanks!', datetime(2025, 9, 10, 10, 4)),
+        ]
+        self.view.items = self.view.messages
+        self.view.cursor_idx = 0
+        self.view.message_cursor_idx = 0
+
+    def test_status_footer_appears_with_messages(self):
+        """Test that status footer appears when messages are present."""
+        lines = self.view.get_display_lines(height=20, width=50, colors_enabled=False)
+
+        # Look for status footer
+        footer_found = False
+        for line in lines[-3:]:  # Check last few lines
+            if isinstance(line, str) and "(" in line and "/" in line and ")" in line:
+                footer_found = True
+                # Should show (5/5) for last position (bottom-anchored)
+                assert "(5/5)" in line, f"Expected (5/5) in footer, got: {line}"
+                break
+
+        assert footer_found, "Status footer not found in display lines"
+
+    def test_status_footer_updates_with_cursor(self):
+        """Test that status footer updates when cursor moves."""
+        # Initial position
+        lines = self.view.get_display_lines(height=20, width=50, colors_enabled=False)
+        initial_footer = None
+        for line in lines[-3:]:
+            if isinstance(line, str) and "(" in line and "/" in line and ")" in line:
+                initial_footer = line.strip()
+                break
+        assert "(5/5)" in initial_footer  # Bottom-anchored, starts at last message
+
+        # Move cursor to position 2
+        self.view.cursor_idx = 2
+        self.view.message_cursor_idx = 2
+        lines = self.view.get_display_lines(height=20, width=50, colors_enabled=False)
+        updated_footer = None
+        for line in lines[-3:]:
+            if isinstance(line, str) and "(" in line and "/" in line and ")" in line:
+                updated_footer = line.strip()
+                break
+        assert "(3/5)" in updated_footer, f"Expected (3/5), got: {updated_footer}"
+
+        # Move to last position
+        self.view.cursor_idx = 4
+        self.view.message_cursor_idx = 4
+        lines = self.view.get_display_lines(height=20, width=50, colors_enabled=False)
+        final_footer = None
+        for line in lines[-3:]:
+            if isinstance(line, str) and "(" in line and "/" in line and ")" in line:
+                final_footer = line.strip()
+                break
+        assert "(5/5)" in final_footer, f"Expected (5/5), got: {final_footer}"
+
+    def test_status_footer_no_messages(self):
+        """Test that no footer appears when there are no messages."""
+        self.view.messages = []
+        self.view.items = []
+
+        lines = self.view.get_display_lines(height=20, width=50, colors_enabled=False)
+
+        # Should not have status footer
+        footer_found = False
+        for line in lines:
+            if isinstance(line, str) and "(" in line and "/" in line and ")" in line:
+                if any(c.isdigit() for c in line):
+                    footer_found = True
+                    break
+
+        assert not footer_found, "Should not show status footer when no messages"
+        # Should show "No messages" message instead
+        assert any("No messages" in str(line) for line in lines), "Should show 'No messages' message"
+
+    def test_status_footer_colored(self):
+        """Test that status footer uses metadata color when colors enabled."""
+        lines = self.view.get_display_lines(height=20, width=50, colors_enabled=True)
+
+        # Look for colored footer
+        footer_found = False
+        for line in lines[-3:]:
+            if isinstance(line, list):  # Colored lines are lists of tuples
+                text = "".join(t for t, _ in line)
+                if "(" in text and "/" in text and ")" in text:
+                    footer_found = True
+                    # Check color of footer
+                    for part_text, part_color in line:
+                        if "(" in part_text:  # Found the footer part
+                            assert part_color == COLOR_METADATA, f"Footer should use COLOR_METADATA, got {part_color}"
+                    break
+
+        assert footer_found, "Colored status footer not found"
+
+    def test_status_footer_right_aligned(self):
+        """Test that status footer is right-aligned."""
+        width = 40
+        lines = self.view.get_display_lines(height=20, width=width, colors_enabled=False)
+
+        # Find footer
+        footer_line = None
+        for line in lines[-3:]:
+            if isinstance(line, str) and "(" in line and "/" in line and ")" in line:
+                footer_line = line
+                break
+
+        assert footer_line is not None, "Footer not found"
+
+        # Footer should be right-aligned
+        assert footer_line.rstrip().endswith(")"), "Footer should be right-aligned"
+        assert "(5/5)" in footer_line  # Bottom-anchored, starts at last message
+
+        # Check that it's padded with spaces on the left
+        assert footer_line.startswith(" "), "Footer should have left padding for right alignment"
+
+    def test_status_footer_with_single_message(self):
+        """Test status footer with single message."""
+        self.view.messages = [('user', 'Single message', None)]
+        self.view.items = self.view.messages
+        self.view.cursor_idx = 0
+        self.view.message_cursor_idx = 0
+
+        lines = self.view.get_display_lines(height=20, width=50, colors_enabled=False)
+
+        footer_found = False
+        for line in lines[-3:]:
+            if isinstance(line, str) and "(" in line and "/" in line and ")" in line:
+                footer_found = True
+                assert "(1/1)" in line, f"Expected (1/1) for single message, got: {line}"
+                break
+
+        assert footer_found, "Footer should appear even with single message"
+
+    def test_status_footer_respects_height_limit(self):
+        """Test that footer fits within available height."""
+        # Very limited height
+        lines = self.view.get_display_lines(height=8, width=50, colors_enabled=False)
+
+        # Should not exceed height limit
+        assert len(lines) <= 8, f"Lines should fit within height limit, got {len(lines)} lines"
+
+        # Footer should still appear if there's room
+        footer_found = any(
+            isinstance(line, str) and "(" in line and "/" in line and ")" in line
+            for line in lines
+        )
+        # Footer is optional if no space, so we don't assert it must be there

--- a/python/tests/test_messages_view_colors.py
+++ b/python/tests/test_messages_view_colors.py
@@ -124,20 +124,23 @@ class TestMessagesViewColors:
     def test_message_content_default_color(self):
         """Test that message content has default color."""
         lines = self.view.get_display_lines(height=30, width=60, colors_enabled=True)
-        
+
         # Find content lines
         content_found = False
         for line in lines:
             if isinstance(line, list):
                 text_combined = "".join(t for t, _ in line)
-                # Content lines are indented
+                # Skip the status footer (it contains parentheses with numbers)
+                if "(" in text_combined and "/" in text_combined and ")" in text_combined:
+                    continue
+                # Content lines are indented (4 spaces)
                 if text_combined.startswith("    ") and text_combined.strip():
                     content_found = True
                     # Check content has default color
                     for text, color in line:
                         if text.strip() and not text.isspace():
                             assert color == COLOR_DEFAULT, f"Content should be default: '{text}'"
-        
+
         assert content_found, "No content lines found"
     
     def test_multiline_message_coloring(self):

--- a/tests/framework/mock_claude_logs.py
+++ b/tests/framework/mock_claude_logs.py
@@ -1,0 +1,144 @@
+"""Helper module to create mock Claude logs for E2E testing."""
+
+import json
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Dict, Any, Tuple
+
+
+def create_mock_session_file(
+    output_path: Path,
+    messages: List[Tuple[str, str]],
+    project_name: str = "test-project",
+    start_time: datetime = None
+) -> Dict[str, Any]:
+    """Create a mock JSONL session file similar to Claude logs.
+
+    Args:
+        output_path: Path where the JSONL file will be created
+        messages: List of (role, content) tuples
+        project_name: Name of the project for metadata
+        start_time: Starting timestamp for messages
+
+    Returns:
+        Dictionary with session metadata (id, size, project, accessible)
+    """
+    if start_time is None:
+        start_time = datetime.now() - timedelta(hours=2)
+
+    session_id = str(uuid.uuid4())
+    log_entries = []
+    current_time = start_time
+
+    # Generate messages in Claude log format
+    for i, (role, content) in enumerate(messages):
+        msg_uuid = f"msg_{uuid.uuid4().hex[:8]}"
+
+        log_entry = {
+            "parentUuid": None if i == 0 else f"msg_{uuid.uuid4().hex[:8]}",
+            "isSidechain": False,
+            "userType": "external" if role == "user" else "assistant",
+            "cwd": f"/Users/testuser/Projects/{project_name}",
+            "sessionId": session_id,
+            "version": "1.0.109",
+            "gitBranch": "main",
+            "type": role,
+            "message": {
+                "role": role,
+                "content": [
+                    {
+                        "type": "text",
+                        "text": content
+                    }
+                ]
+            },
+            "uuid": msg_uuid,
+            "timestamp": current_time.isoformat() + "Z"
+        }
+
+        # Add model for assistant messages
+        if role == "assistant":
+            log_entry["message"]["model"] = "claude-3-5-sonnet-20241022"
+
+        log_entries.append(log_entry)
+
+        # Advance time for next message
+        current_time += timedelta(minutes=2)
+
+    # Write JSONL file
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, 'w') as f:
+        for entry in log_entries:
+            f.write(json.dumps(entry) + '\n')
+
+    # Return metadata
+    return {
+        'id': session_id,
+        'accessible': True,
+        'size': output_path.stat().st_size,
+        'project': project_name,
+        'modified': datetime.now().isoformat()
+    }
+
+
+def create_mock_claude_home(
+    base_path: Path,
+    sessions_data: List[List[Tuple[str, str]]] = None,
+    cwd: Path = None
+) -> List[Tuple[str, Dict[str, Any]]]:
+    """Create a mock ~/.claude directory structure with session files.
+
+    Args:
+        base_path: Base path for the mock home directory
+        sessions_data: List of message lists, each containing (role, content) tuples.
+                      If None, creates default test sessions.
+        cwd: Current working directory to determine project folder name.
+             If None, uses /Users/basicthinker/Projects/tigs/tests
+
+    Returns:
+        List of tuples (log_id, metadata) compatible with cligent
+    """
+    # Determine the project folder name based on cwd
+    if cwd is None:
+        # Default to the python directory since that's where tests run from (PYTHON_DIR)
+        cwd = Path("/Users/basicthinker/Projects/tigs/python")
+
+    # Convert path to project folder name (replace / with -)
+    # Cligent keeps the leading dash, so we should too
+    project_folder_name = str(cwd).replace('/', '-')
+
+    # Create the correct directory structure that cligent expects
+    claude_dir = base_path / '.claude' / 'projects' / project_folder_name
+    claude_dir.mkdir(parents=True, exist_ok=True)
+
+    # Default test sessions if none provided
+    if sessions_data is None:
+        sessions_data = [
+            [
+                ("user", "Test message 1"),
+                ("assistant", "Test response 1"),
+                ("user", "Test message 2"),
+                ("assistant", "Test response 2")
+            ]
+        ]
+
+    logs = []
+    start_time = datetime.now() - timedelta(days=1)
+
+    for i, messages in enumerate(sessions_data):
+        # Create session file directly in the project folder with UUID name
+        session_id = str(uuid.uuid4())
+        session_file = claude_dir / f"{session_id}.jsonl"
+
+        metadata = create_mock_session_file(
+            session_file,
+            messages=messages,
+            project_name=project_folder_name,
+            start_time=start_time + timedelta(hours=i*3)
+        )
+
+        # Use the session UUID as log ID (this is what cligent expects)
+        logs.append((session_id, metadata))
+
+    return logs

--- a/tests/store/commits/test_status_footer.py
+++ b/tests/store/commits/test_status_footer.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Test status footer display in commits view for store command."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from framework.tui import TUI, get_first_pane
+from framework.fixtures import create_test_repo
+from framework.paths import PYTHON_DIR
+
+
+class TestCommitsStatusFooter:
+    """Test the status footer display in commits view."""
+
+    def test_status_footer_display(self):
+        """Test that status footer shows current position."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "footer_test_repo"
+
+            # Create a simple repo with just 10 commits to ensure footer is visible
+            commits = [f"Commit {i}" for i in range(1, 11)]
+            create_test_repo(repo_path, commits)
+
+            command = f"uv run tigs --repo {repo_path} store"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Commits")
+
+                # Capture initial display
+                lines = tui.capture()
+
+                # Look for status footer in commits pane (first column)
+                footer_found = False
+
+                # Check all lines, looking in the first pane (commits column)
+                for i, line in enumerate(lines):
+                    first_pane = get_first_pane(line)
+                    # Look for the status footer pattern (X/Y)
+                    import re
+                    if re.search(r'\(\d+/\d+\)', first_pane):
+                        footer_found = True
+                        # Should show (1/10) for first commit
+                        assert "(1/10)" in first_pane, f"Expected (1/10), got: {first_pane}"
+                        break
+
+                assert footer_found, "Status footer not found in commits pane"
+
+    def test_status_footer_updates_on_navigation(self, test_repo):
+        """Test that status footer updates when navigating commits."""
+
+        command = f"uv run tigs --repo {test_repo} store"
+
+        with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+            # Wait for UI to load
+            tui.wait_for("Commits")
+
+            # Check initial position
+            initial_lines = tui.capture()
+            initial_footer = None
+            for line in initial_lines[-10:]:
+                first_pane = get_first_pane(line)
+                if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                    initial_footer = first_pane.strip()
+                    break
+
+            assert initial_footer, "Initial footer not found"
+            assert "(1/50)" in initial_footer
+
+            # Move cursor down
+            tui.send_arrow("down")
+
+            # Check updated position
+            new_lines = tui.capture()
+            new_footer = None
+            for line in new_lines[-10:]:
+                first_pane = get_first_pane(line)
+                if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                    new_footer = first_pane.strip()
+                    break
+
+            assert new_footer, "Updated footer not found"
+            assert "(2/50)" in new_footer, f"Expected (2/50), got: {new_footer}"
+
+            # Move down a few more times
+            for _ in range(3):
+                tui.send_arrow("down")
+
+            # Check position again
+            final_lines = tui.capture()
+            final_footer = None
+            for line in final_lines[-10:]:
+                first_pane = get_first_pane(line)
+                if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                    final_footer = first_pane.strip()
+                    break
+
+            assert final_footer, "Final footer not found"
+            assert "(5/50)" in final_footer, f"Expected (5/50), got: {final_footer}"
+
+    def test_status_footer_with_empty_repo(self):
+        """Test status footer behavior with no commits."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "empty_repo"
+            create_test_repo(repo_path, [])  # Empty repo
+
+            command = f"uv run tigs --repo {repo_path} store"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Commits")
+
+                # Capture display
+                lines = tui.capture()
+
+                # Should not show status footer for empty repo
+                footer_found = False
+                for line in lines:
+                    first_pane = get_first_pane(line)
+                    if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                        # Make sure it's not from other panes
+                        if "commits" in first_pane.lower() or any(c.isdigit() for c in first_pane):
+                            footer_found = True
+                            break
+
+                # Empty repo should show "No commits" message instead of footer
+                assert not footer_found or "(0/" not in str(lines), "Should not show status footer for empty repo"
+
+    def test_status_footer_with_single_commit(self):
+        """Test status footer with single commit."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "single_commit_repo"
+            create_test_repo(repo_path, ["Single commit"])
+
+            command = f"uv run tigs --repo {repo_path} store"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Commits")
+
+                # Capture display
+                lines = tui.capture()
+
+                # Look for status footer
+                footer_found = False
+                for line in lines[-10:]:
+                    first_pane = get_first_pane(line)
+                    if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                        footer_found = True
+                        # Should show (1/1) for single commit
+                        assert "(1/1)" in first_pane, f"Expected (1/1), got: {first_pane}"
+                        break
+
+                assert footer_found, "Status footer not found for single commit"

--- a/tests/store/messages/test_display.py
+++ b/tests/store/messages/test_display.py
@@ -10,34 +10,34 @@ import pytest
 
 from framework.tui import TUI
 from framework.fixtures import create_test_repo
+from framework.mock_claude_logs import create_mock_claude_home
 from framework.paths import PYTHON_DIR
 
 
 @pytest.fixture
-def messages_setup():
+def messages_setup(monkeypatch):
     """Create repo and messages for message testing."""
     with tempfile.TemporaryDirectory() as tmpdir:
         repo_path = Path(tmpdir) / "repo"
-        logs_path = Path(tmpdir) / "logs"
-        
+        mock_home = Path(tmpdir) / "mock_home"
+        mock_home.mkdir()
+
+        # Mock HOME environment variable
+        monkeypatch.setenv("HOME", str(mock_home))
+
         # Create repo with minimal commits
         commits = [f"Test commit {i+1}" for i in range(5)]
         create_test_repo(repo_path, commits)
         
-        # Create log with several messages
-        logs_path.mkdir(parents=True, exist_ok=True)
-
-        log_file = logs_path / "log_20250107_141500.jsonl"
-        messages = []
+        # Create mock Claude logs with several messages
+        sessions_data = [[]]
         for i in range(8):
-            messages.append(f'{{"role": "user", "content": "User message {i+1}: Question about the code"}}')
-            messages.append(f'{{"role": "assistant", "content": "Assistant message {i+1}: Here is the detailed answer with explanations"}}')
+            sessions_data[0].append(("user", f"User message {i+1}: Question about the code"))
+            sessions_data[0].append(("assistant", f"Assistant message {i+1}: Here is the detailed answer with explanations"))
 
-        log_file.write_text('\n'.join(messages))
-        log_file.touch()
-        os.utime(log_file, times=(time.time(), time.time()))
-        
-        yield repo_path, logs_path
+        create_mock_claude_home(mock_home, sessions_data)
+
+        yield repo_path, mock_home
 
 
 class TestMessageDisplay:
@@ -45,15 +45,11 @@ class TestMessageDisplay:
     
     def test_message_format_and_display(self, messages_setup):
         """Test message formatting and basic display."""
-        repo_path, logs_path = messages_setup
-        
-        import os
-        env = os.environ.copy()
-        env['TIGS_LOGS_DIR'] = str(logs_path)
+        repo_path, mock_home = messages_setup
         
         command = f"uv run tigs --repo {repo_path} store"
         
-        with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120), env=env) as tui:
+        with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120), env={"HOME": str(mock_home)}) as tui:
             try:
                 tui.wait_for("Messages", timeout=5.0)
                 
@@ -89,15 +85,11 @@ class TestMessageDisplay:
     
     def test_bottom_anchored_display(self, messages_setup):
         """Test bottom-anchored message display behavior."""
-        repo_path, logs_path = messages_setup
-        
-        import os
-        env = os.environ.copy()
-        env['TIGS_LOGS_DIR'] = str(logs_path)
+        repo_path, mock_home = messages_setup
         
         command = f"uv run tigs --repo {repo_path} store"
         
-        with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120), env=env) as tui:
+        with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120), env={"HOME": str(mock_home)}) as tui:
             try:
                 tui.wait_for("Messages", timeout=5.0)
                 

--- a/tests/store/messages/test_status_footer.py
+++ b/tests/store/messages/test_status_footer.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Test status footer display in messages view for store command."""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from framework.tui import TUI, get_middle_pane
+from framework.fixtures import create_test_repo
+from framework.paths import PYTHON_DIR
+
+
+class TestMessagesStatusFooter:
+    """Test the status footer display in messages view."""
+
+    def test_status_footer_display(self):
+        """Test that status footer shows current position."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "messages_footer_test_repo"
+
+            # Create a repo with a commit
+            create_test_repo(repo_path, ["Initial commit"])
+
+            # Get the commit SHA
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True
+            )
+            sha = result.stdout.strip()
+
+            # Add chat to the commit
+            chat = """schema: tigs.chat/v1
+messages:
+- role: user
+  content: How do I implement a binary search?
+- role: assistant
+  content: Here's how to implement binary search:
+- role: user
+  content: Can you show an example?
+- role: assistant
+  content: Sure, here's a Python example:
+- role: user
+  content: Thanks!
+"""
+            subprocess.run(
+                ["git", "notes", "--ref=refs/notes/chats", "add", "-m", chat, sha],
+                cwd=repo_path,
+                check=True
+            )
+
+            command = f"uv run tigs --repo {repo_path} store"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Commits")
+
+                # Select the first commit to view messages
+                tui.send(" ")
+
+                # Wait for messages to appear
+                tui.wait_for("User")
+
+                # Capture display
+                lines = tui.capture()
+
+                # Look for status footer in messages pane (second column)
+                footer_found = False
+                for line in lines[-10:]:
+                    second_pane = get_middle_pane(line)
+                    # Look for the status footer pattern (X/Y)
+                    if "(" in second_pane and "/" in second_pane and ")" in second_pane:
+                        footer_found = True
+                        # Should show (1/5) for first message
+                        assert "(1/5)" in second_pane, f"Expected (1/5), got: {second_pane}"
+                        break
+
+                assert footer_found, "Status footer not found in messages pane"
+
+    def test_status_footer_updates_on_navigation(self):
+        """Test that status footer updates when navigating messages."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "messages_nav_test_repo"
+
+            # Create a repo with a commit
+            create_test_repo(repo_path, ["Chat commit"])
+
+            # Get the commit SHA
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True
+            )
+            sha = result.stdout.strip()
+
+            # Add chat to the commit
+            chat = """schema: tigs.chat/v1
+messages:
+- role: user
+  content: Message 1
+- role: assistant
+  content: Response 1
+- role: user
+  content: Message 2
+- role: assistant
+  content: Response 2
+- role: user
+  content: Message 3
+- role: assistant
+  content: Response 3
+"""
+            subprocess.run(
+                ["git", "notes", "--ref=refs/notes/chats", "add", "-m", chat, sha],
+                cwd=repo_path,
+                check=True
+            )
+
+            command = f"uv run tigs --repo {repo_path} store"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Commits")
+
+                # Select the first commit
+                tui.send(" ")
+
+                # Wait for messages
+                tui.wait_for("Message 1")
+
+                # Check initial position
+                initial_lines = tui.capture()
+                initial_footer = None
+                for line in initial_lines[-10:]:
+                    second_pane = get_middle_pane(line)
+                    if "(" in second_pane and "/" in second_pane and ")" in second_pane:
+                        initial_footer = second_pane.strip()
+                        break
+
+                assert initial_footer, "Initial footer not found"
+                assert "(1/6)" in initial_footer
+
+                # Tab to messages pane
+                tui.send("\t")
+
+                # Move cursor down
+                tui.send_arrow("down")
+
+                # Check updated position
+                new_lines = tui.capture()
+                new_footer = None
+                for line in new_lines[-10:]:
+                    second_pane = get_middle_pane(line)
+                    if "(" in second_pane and "/" in second_pane and ")" in second_pane:
+                        new_footer = second_pane.strip()
+                        break
+
+                assert new_footer, "Updated footer not found"
+                assert "(2/6)" in new_footer, f"Expected (2/6), got: {new_footer}"
+
+                # Move down more
+                for _ in range(3):
+                    tui.send_arrow("down")
+
+                # Check position again
+                final_lines = tui.capture()
+                final_footer = None
+                for line in final_lines[-10:]:
+                    second_pane = get_middle_pane(line)
+                    if "(" in second_pane and "/" in second_pane and ")" in second_pane:
+                        final_footer = second_pane.strip()
+                        break
+
+                assert final_footer, "Final footer not found"
+                assert "(5/6)" in final_footer, f"Expected (5/6), got: {final_footer}"
+
+    def test_status_footer_no_messages(self):
+        """Test status footer behavior when no messages selected."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "no_messages_repo"
+
+            # Create a repo with commits but no chats
+            create_test_repo(repo_path, ["Commit without chat"])
+
+            command = f"uv run tigs --repo {repo_path} store"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Commits")
+
+                # Don't select any commit
+                # Capture display
+                lines = tui.capture()
+
+                # Should not have status footer in messages pane
+                footer_found = False
+                for line in lines:
+                    second_pane = get_middle_pane(line)
+                    if "(" in second_pane and "/" in second_pane and ")" in second_pane:
+                        # Make sure it's not from other content
+                        if any(c.isdigit() for c in second_pane):
+                            footer_found = True
+                            break
+
+                assert not footer_found, "Should not show status footer when no messages"
+
+                # Should show "No messages" message instead
+                has_no_messages = False
+                for line in lines:
+                    second_pane = get_middle_pane(line)
+                    if "No messages" in second_pane:
+                        has_no_messages = True
+                        break
+
+                assert has_no_messages, "Should show 'No messages' message"
+
+    def test_status_footer_single_message(self):
+        """Test status footer with single message."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "single_message_repo"
+
+            # Create a repo with a commit
+            create_test_repo(repo_path, ["Single chat"])
+
+            # Get the commit SHA
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True
+            )
+            sha = result.stdout.strip()
+
+            # Add chat with single message
+            chat = """schema: tigs.chat/v1
+messages:
+- role: user
+  content: Single message
+"""
+            subprocess.run(
+                ["git", "notes", "--ref=refs/notes/chats", "add", "-m", chat, sha],
+                cwd=repo_path,
+                check=True
+            )
+
+            command = f"uv run tigs --repo {repo_path} store"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Commits")
+
+                # Select the first commit
+                tui.send(" ")
+
+                # Wait for message
+                tui.wait_for("Single message")
+
+                # Capture display
+                lines = tui.capture()
+
+                # Look for status footer
+                footer_found = False
+                for line in lines[-10:]:
+                    second_pane = get_middle_pane(line)
+                    if "(" in second_pane and "/" in second_pane and ")" in second_pane:
+                        footer_found = True
+                        # Should show (1/1) for single message
+                        assert "(1/1)" in second_pane, f"Expected (1/1), got: {second_pane}"
+                        break
+
+                assert footer_found, "Status footer not found for single message"

--- a/tests/view/test_status_footer.py
+++ b/tests/view/test_status_footer.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Test status footer display in commits view for view command."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from framework.tui import TUI, get_first_pane
+from framework.fixtures import create_test_repo
+from framework.paths import PYTHON_DIR
+
+
+class TestViewStatusFooter:
+    """Test the status footer display in view command's commits pane."""
+
+    def test_view_status_footer_display(self):
+        """Test that status footer shows in view command."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "view_repo"
+
+            # Create test repo with known number of commits
+            commits = [f"Commit {i}" for i in range(1, 11)]  # 10 commits
+            create_test_repo(repo_path, commits)
+
+            command = f"uv run tigs --repo {repo_path} view"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Commit")
+
+                # Capture initial display
+                lines = tui.capture()
+
+                # Look for status footer in commits pane (first column)
+                footer_found = False
+                for line in lines[-10:]:  # Check last 10 lines
+                    first_pane = get_first_pane(line)
+                    # Status footer format: (1/10)
+                    if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                        footer_found = True
+                        print(f"Found view status footer: {first_pane.strip()}")
+                        # Should show (1/10) for first commit
+                        assert "(1/10)" in first_pane, f"Expected (1/10), got: {first_pane}"
+                        break
+
+                assert footer_found, "Status footer not found in view command"
+
+    def test_view_status_footer_navigation(self):
+        """Test that status footer updates in view command."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "view_nav_repo"
+
+            # Create test repo
+            commits = [f"Change {i}" for i in range(1, 6)]  # 5 commits
+            create_test_repo(repo_path, commits)
+
+            command = f"uv run tigs --repo {repo_path} view"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Change")
+
+                # Check initial position
+                initial_lines = tui.capture()
+                initial_footer = None
+                for line in initial_lines[-10:]:
+                    first_pane = get_first_pane(line)
+                    if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                        initial_footer = first_pane.strip()
+                        break
+
+                assert initial_footer, "Initial footer not found"
+                assert "(1/5)" in initial_footer
+
+                # Move cursor down
+                tui.send_arrow("down")
+
+                # Check updated position
+                new_lines = tui.capture()
+                new_footer = None
+                for line in new_lines[-10:]:
+                    first_pane = get_first_pane(line)
+                    if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                        new_footer = first_pane.strip()
+                        break
+
+                assert new_footer, "Updated footer not found"
+                assert "(2/5)" in new_footer, f"Expected (2/5), got: {new_footer}"
+
+                # Move to last commit
+                for _ in range(3):
+                    tui.send_arrow("down")
+
+                # Check final position
+                final_lines = tui.capture()
+                final_footer = None
+                for line in final_lines[-10:]:
+                    first_pane = get_first_pane(line)
+                    if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                        final_footer = first_pane.strip()
+                        break
+
+                assert final_footer, "Final footer not found"
+                assert "(5/5)" in final_footer, f"Expected (5/5), got: {final_footer}"
+
+    def test_view_read_only_mode_has_footer(self):
+        """Test that read-only mode (view command) shows footer."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_path = Path(tmpdir) / "readonly_repo"
+
+            # Create test repo
+            commits = ["Test commit 1", "Test commit 2", "Test commit 3"]
+            create_test_repo(repo_path, commits)
+
+            command = f"uv run tigs --repo {repo_path} view"
+
+            with TUI(command, cwd=PYTHON_DIR, dimensions=(30, 120)) as tui:
+                # Wait for UI to load
+                tui.wait_for("Test commit")
+
+                # Capture display
+                lines = tui.capture()
+
+                # Verify read-only mode indicators (no checkboxes)
+                has_checkbox = False
+                for line in lines:
+                    first_pane = get_first_pane(line)
+                    if "[ ]" in first_pane or "[x]" in first_pane:
+                        has_checkbox = True
+                        break
+
+                assert not has_checkbox, "View command should not have checkboxes"
+
+                # Verify footer is still present
+                footer_found = False
+                for line in lines[-10:]:
+                    first_pane = get_first_pane(line)
+                    if "(" in first_pane and "/" in first_pane and ")" in first_pane:
+                        footer_found = True
+                        assert "(1/3)" in first_pane or "(2/3)" in first_pane or "(3/3)" in first_pane
+                        break
+
+                assert footer_found, "Status footer should be present in read-only mode"


### PR DESCRIPTION
## Summary
- Adds position status footer (X/Y) to commits view, messages pane, and logs pane
- Shows current selection position and total count for better navigation feedback
- Implements consistent footer format across all three views

## Changes
- Added status footer to commits view showing cursor position
- Added status footer to messages pane showing selected message position  
- Added status footer to logs pane showing selected log position
- Fixed width calculation for proper alignment

Closes #46

## Test plan
- [x] Status footers display correctly in commits view
- [x] Status footers display correctly in messages pane
- [x] Status footers display correctly in logs pane
- [x] Position updates correctly on navigation

🤖 Generated with [Claude Code](https://claude.ai/code)